### PR TITLE
Fix create-run variable flag handling

### DIFF
--- a/command.go
+++ b/command.go
@@ -25,6 +25,71 @@ type Parameter struct {
 	value       *string
 }
 
+func parameterValue(flags map[string]Parameter, name string) string {
+	flag, ok := flags[name]
+	if !ok || flag.value == nil {
+		return ""
+	}
+
+	return strings.TrimSpace(*flag.value)
+}
+
+func buildCreateRunVariables(flags map[string]Parameter) []any {
+	key := parameterValue(flags, "variables-key")
+	if key == "" {
+		key = parameterValue(flags, "inputs-name")
+	}
+
+	value := parameterValue(flags, "variables-value")
+	if value == "" {
+		value = parameterValue(flags, "inputs-value")
+	}
+
+	sensitive := parameterValue(flags, "variables-sensitive")
+	if sensitive == "" {
+		sensitive = parameterValue(flags, "inputs-sensitive")
+	}
+
+	category := parameterValue(flags, "variables-category")
+	if category == "" && (parameterValue(flags, "inputs-name") != "" ||
+		parameterValue(flags, "inputs-value") != "" ||
+		parameterValue(flags, "inputs-sensitive") != "") {
+		category = "terraform"
+	}
+
+	hcl := parameterValue(flags, "variables-hcl")
+
+	if key == "" && value == "" && category == "" && sensitive == "" && hcl == "" {
+		return nil
+	}
+
+	variable := map[string]any{}
+
+	if key != "" {
+		variable["key"] = key
+	}
+
+	if value != "" {
+		variable["value"] = value
+	}
+
+	if category != "" {
+		variable["category"] = category
+	}
+
+	if sensitive != "" {
+		val, _ := strconv.ParseBool(sensitive)
+		variable["sensitive"] = val
+	}
+
+	if hcl != "" {
+		val, _ := strconv.ParseBool(hcl)
+		variable["hcl"] = val
+	}
+
+	return []any{variable}
+}
+
 // Rename flags with odd names that causes issues in some shells
 func renameFlag(name string) string {
 	name = strings.ReplaceAll(name, "[", "-")
@@ -382,6 +447,12 @@ func parseCommand(format string, verbose bool, quiet bool) {
 						}
 
 						collectAttributes(action.RequestBody.Value.Content[contentType].Schema.Value, "")
+
+						if command == "create-run" {
+							if variables := buildCreateRunVariables(flags); len(variables) > 0 {
+								raw.SetP(variables, "data.attributes.variables")
+							}
+						}
 
 						body = raw.StringIndent("", "  ")
 					}

--- a/command_test.go
+++ b/command_test.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"testing"
+)
+
+func stringPtr(value string) *string {
+	return &value
+}
+
+func TestBuildCreateRunVariablesFromVariableFlags(t *testing.T) {
+	flags := map[string]Parameter{
+		"variables-key": {
+			value: stringPtr("image_tag"),
+		},
+		"variables-value": {
+			value: stringPtr("pr-123"),
+		},
+		"variables-category": {
+			value: stringPtr("terraform"),
+		},
+		"variables-sensitive": {
+			value: stringPtr("true"),
+		},
+		"variables-hcl": {
+			value: stringPtr("false"),
+		},
+	}
+
+	variables := buildCreateRunVariables(flags)
+	if len(variables) != 1 {
+		t.Fatalf("expected one variable object, got %d", len(variables))
+	}
+
+	variable := variables[0].(map[string]any)
+	if variable["key"] != "image_tag" {
+		t.Fatalf("expected key to be image_tag, got %#v", variable["key"])
+	}
+
+	if variable["value"] != "pr-123" {
+		t.Fatalf("expected value to be pr-123, got %#v", variable["value"])
+	}
+
+	if variable["category"] != "terraform" {
+		t.Fatalf("expected category to be terraform, got %#v", variable["category"])
+	}
+
+	if variable["sensitive"] != true {
+		t.Fatalf("expected sensitive to be true, got %#v", variable["sensitive"])
+	}
+
+	if variable["hcl"] != false {
+		t.Fatalf("expected hcl to be false, got %#v", variable["hcl"])
+	}
+}
+
+func TestBuildCreateRunVariablesFromInputsFlags(t *testing.T) {
+	flags := map[string]Parameter{
+		"inputs-name": {
+			value: stringPtr("image_tag"),
+		},
+		"inputs-value": {
+			value: stringPtr("pr-123"),
+		},
+		"inputs-sensitive": {
+			value: stringPtr("false"),
+		},
+	}
+
+	variables := buildCreateRunVariables(flags)
+	if len(variables) != 1 {
+		t.Fatalf("expected one variable object, got %d", len(variables))
+	}
+
+	variable := variables[0].(map[string]any)
+	if variable["key"] != "image_tag" {
+		t.Fatalf("expected key to be image_tag, got %#v", variable["key"])
+	}
+
+	if variable["value"] != "pr-123" {
+		t.Fatalf("expected value to be pr-123, got %#v", variable["value"])
+	}
+
+	if variable["category"] != "terraform" {
+		t.Fatalf("expected category to default to terraform, got %#v", variable["category"])
+	}
+
+	if variable["sensitive"] != false {
+		t.Fatalf("expected sensitive to be false, got %#v", variable["sensitive"])
+	}
+}
+
+func TestBuildCreateRunVariablesPrefersExplicitVariableFlags(t *testing.T) {
+	flags := map[string]Parameter{
+		"variables-key": {
+			value: stringPtr("explicit"),
+		},
+		"variables-value": {
+			value: stringPtr("value-from-variables"),
+		},
+		"variables-category": {
+			value: stringPtr("env"),
+		},
+		"inputs-name": {
+			value: stringPtr("ignored"),
+		},
+		"inputs-value": {
+			value: stringPtr("ignored"),
+		},
+	}
+
+	variables := buildCreateRunVariables(flags)
+	variable := variables[0].(map[string]any)
+
+	if variable["key"] != "explicit" {
+		t.Fatalf("expected explicit key to win, got %#v", variable["key"])
+	}
+
+	if variable["value"] != "value-from-variables" {
+		t.Fatalf("expected explicit value to win, got %#v", variable["value"])
+	}
+
+	if variable["category"] != "env" {
+		t.Fatalf("expected explicit category to win, got %#v", variable["category"])
+	}
+}


### PR DESCRIPTION
## Summary
- fix `create-run` so `-variables-*` flags are serialized into `data.attributes.variables`
- treat `-inputs-*` as a compatibility alias for Terraform run variables
- add unit tests for explicit variable flags, input alias flags, and precedence behavior

## Problem
`scalr create-run` accepted `-variables-*` and `-inputs-*` flags, but silently dropped them from the request body. The run was created, but the response showed `variables: []` and empty `inputs`, so CI/CD callers could not pass run-scoped values through the CLI.

## Root Cause
The generic body builder in `command.go` does not construct non-relationship arrays of objects for request bodies. `create-run` stores run-scoped values in `data.attributes.variables`, which is an array of objects, so the existing parser exposed the flags but never wrote them into the JSON payload.

## Fix
This PR adds a targeted `create-run` body helper that:
- builds `data.attributes.variables` from `-variables-key`, `-variables-value`, `-variables-category`, `-variables-sensitive`, and `-variables-hcl`
- treats `-inputs-name`, `-inputs-value`, and `-inputs-sensitive` as a compatibility alias that maps to a Terraform variable
- prefers explicit `-variables-*` flags if both forms are present

## Testing
- `go test -run 'TestBuildCreateRunVariables' ./...`
- manual reproduction against real Scalr API using the customer scenario
  - before: request body omitted `variables`
  - after: request body includes `data.attributes.variables`
  - after: API response returns the passed variable under `variables` with the provided value
